### PR TITLE
DarkSky API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1733,6 +1733,11 @@
         }
       }
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "nopt": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "express": "~4.16.1",
     "hat": "0.0.3",
     "morgan": "^1.9.1",
+    "node-fetch": "^2.6.0",
     "pg": "^7.12.1",
     "sequelize": "^5.15.0",
     "sequelize-cli": "^5.5.0"

--- a/services/darksky_api.js
+++ b/services/darksky_api.js
@@ -1,0 +1,108 @@
+require('dotenv').config()
+const fetch = require('node-fetch')
+
+class DarkSky {
+  forecast(lat, long) {
+    fetch(`https://api.darksky.net/forecast/${process.env.DARKSKY_API_KEY}/${lat},${long}?exclude=minutely,alerts,flags`)
+    .then((response) => {
+      return response.json()
+    })
+    .then((response) => {
+      return this._processed(response)
+    })
+    .catch((err) => {
+      console.log(err)
+    });
+  }
+
+  _processed(response) {
+    return {
+      timezone: response.timezone,
+      currently: this._currently(response.currently),
+      hourly: this._hourly(response.hourly),
+      daily: this._daily(response.daily)
+    }
+  }
+
+  _currently(response) {
+    return {
+      summary: response.summary,
+      icon: response.icon,
+      precipIntensity: response.precipIntensity,
+      precipProbability: response.precipProbability,
+      precipType: response.precipType,
+      temperature: response.temperature,
+      humidity: response.humidity,
+      pressure: response.pressure,
+      windSpeed: response.windSpeed,
+      windGust: response.windGust,
+      windBearing: response.windBearing,
+      cloudCover: response.cloudCover,
+      visibility: response.visibility
+    }
+  }
+
+  _hourly(response) {
+    let hourlies = {
+      summary: response.summary,
+      icon: response.icon,
+      data: []
+    }
+    response.data.forEach(function(forecast) {
+      hourlies.data.push(
+        {
+          time: forecast.time,
+          summary: forecast.summary,
+          icon: forecast.icon,
+          precipIntensity: forecast.precipIntensity,
+          precipProbability: forecast.precipProbability,
+          precipType: forecast.precipType,
+          temperature: forecast.temperature,
+          humidity: forecast.humidity,
+          pressure: forecast.pressure,
+          windSpeed: forecast.windSpeed,
+          windGust: forecast.windGust,
+          windBearing: forecast.windBearing,
+          cloudCover: forecast.cloudCover,
+          visibility: forecast.visibility
+        }
+      )
+    })
+    return hourlies
+  }
+
+  _daily(response) {
+    let dailies = {
+      summary: response.summary,
+      icon: response.icon,
+      data: []
+    }
+    response.data.forEach(function(forecast) {
+      dailies.data.push(
+        {
+          time: forecast.time,
+          summary: forecast.summary,
+          icon: forecast.icon,
+          sunriseTime: forecast.sunriseTime,
+          sunsetTime: forecast.sunsetTime,
+          precipIntensity: forecast.precipIntensity,
+          precipIntensityMax: forecast.precipIntensityMax,
+          precipIntensityMaxTime: forecast.precipIntensityMaxTime,
+          precipProbability: forecast.precipProbability,
+          precipType: forecast.precipType,
+          temperatureHigh: forecast.temperatureHigh,
+          temperatureLow: forecast.temperatureLow,
+          humidity: forecast.humidity,
+          pressure: forecast.pressure,
+          windSpeed: forecast.windSpeed,
+          windGust: forecast.windGust,
+          cloudCover: forecast.cloudCover,
+          visibility: forecast.visibility,
+          temperatureMin: forecast.temperatureMin,
+          temperatureMax: forecast.temperatureMax
+        }
+      )
+    })
+    return dailies
+  }
+}


### PR DESCRIPTION
This PR brings in the functionality of the DarkSky service, reaching out to DarkSky's `forecast` endpoint to receive weather information for `currently`, `hourly`, and `daily`. The DarkSky is a simple API, only requiring a latitude and longitude (that we have received from our Google Maps service), and then returns all the information we need for upcoming weather. Since all we care about are the categories listed above, we can also request that DarkSky does not send their other categories of minutely, alerts, and flags.
At this moment in time, the Service handles the formatting of the information for us. The response from DarkSky is then passed to a `_processed` private method, where it is mapped into a custom object with only the information we need. We store the `timezone` for frontend reference, and then the other categories are parsed in separate private methods as well. We use `forEach` loops to sort through all of the `hourly` and `daily` information, and then storing each object in arrays inside the parent object.

This PR also brings in the `node-fetch`, a zero dependency package that emulates the native `fetch` browser API. This keeps things clean and consistent, and easy to understand across frontend and backend.